### PR TITLE
add semaphore pipeline

### DIFF
--- a/.semaphore/create-github-tag.yml
+++ b/.semaphore/create-github-tag.yml
@@ -1,0 +1,23 @@
+version: v1.0
+name: tasks/create-github-tag
+agent:
+  machine:
+    type: s1-prod-ubuntu24-04-arm64-1
+fail_fast:
+  cancel:
+    when: "true"
+execution_time_limit:
+  minutes: 30
+global_job_config:
+  prologue:
+    commands:
+      - checkout
+blocks:
+  - name: Create Tag
+    dependencies: []
+    task:
+      jobs:
+        - name: Create Tag
+          commands:
+            - git tag ${TAG_NAME}
+            - git push origin ${TAG_NAME}

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,29 @@
+version: v1.0
+name: build
+agent:
+  machine:
+    type: s1-prod-ubuntu24-04-arm64-1
+auto_cancel:
+  running:
+    when: "branch != 'main'"
+execution_time_limit:
+  minutes: 30
+queue:
+  - when: "branch != 'main'"
+    processing: parallel
+global_job_config:
+  env_vars:
+    - name: MAVEN_OPTS
+      value: "-Dmaven.repo.local=.m2"
+  prologue:
+    commands:
+      - sem-version java 17
+      - checkout
+blocks:
+  - name: "Build"
+    dependencies: []
+    task:
+      jobs:
+        - name: "Clean and Install"
+          commands:
+            - ./mvnw clean install

--- a/service.yml
+++ b/service.yml
@@ -16,7 +16,7 @@ semaphore:
       pipeline_file: .semaphore/create-github-tag.yml
       parameters:
         - name: TAG_NAME
-          required: True
+          required: true
           description: The name of the tag to be created.
           default_value: "X.Y.Z"
 make:

--- a/service.yml
+++ b/service.yml
@@ -1,9 +1,25 @@
 name: gcp-qwiklabs-sql-automation
-lang: unknown
-lang_version: unknown
+lang: java
+lang_version: 17
 git:
   enable: true
 codeowners:
   enable: true
 renovatebot:
   enable: false
+semaphore:
+  enable: true
+  pipeline_enable: false
+  tasks:
+    - name: create-github-tag
+      branch: main
+      pipeline_file: .semaphore/create-github-tag.yml
+      parameters:
+        - name: TAG_NAME
+          required: True
+          description: The name of the tag to be created.
+          default_value: "X.Y.Z"
+make:
+  enable: true
+  enable_updates: true
+  update_makefile: true


### PR DESCRIPTION
This PR adds the semaphore files required for a CI pipeline with a task to create a GitHub tag which will enable release artifacts to be created.